### PR TITLE
Contain build artifacts to a pkg directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,2 @@
-mruby*zip
-mruby
-
-*rb.c
-
 build
+pkg

--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ task default: :compile_script
 directory "build"
 directory "pkg"
 
-file "#{MRUBY_PATH}" => "pkg" do
+file MRUBY_PATH => "pkg" do
   sh "wget -c -O #{PKG_PATH}/mruby.zip #{MRUBY_URL}"
   sh "unzip #{PKG_PATH}/mruby.zip -d #{PKG_PATH}"
   dirname = Dir["#{PKG_PATH}/mruby-*"].first
@@ -22,18 +22,16 @@ file "#{MRUBY_PATH}" => "pkg" do
   FileUtils.rm("#{PKG_PATH}/mruby.zip")
 end
 
-file "#{BUILD_CONFIG_PATH}" => [MRUBY_PATH, 'build_config.rb'] do |t|
+file BUILD_CONFIG_PATH => [MRUBY_PATH, 'build_config.rb'] do |t|
   FileUtils.cp 'build_config.rb', t.name
 end
 
 file "#{MRUBY_PATH}/bin" => [MRUBY_PATH, BUILD_CONFIG_PATH]
 file "#{MRUBY_PATH}/build" => "#{MRUBY_PATH}/bin"
 
-file "#{MRBC_PATH}" => [MRUBY_PATH, BUILD_CONFIG_PATH] + Dir.glob('ext/**/*.rb') + Dir.glob('ext/**/*.c') do
+file MRBC_PATH => [MRUBY_PATH, BUILD_CONFIG_PATH] + Dir.glob('ext/**/*.rb') + Dir.glob('ext/**/*.c') do
   ENV['MRUBY_CONFIG'] = BUILD_CONFIG
-  puts "in here #{MRUBY_PATH}"
   Dir.chdir(MRUBY_PATH) { sh 'rake' }
-  puts "out here"
 end
 
 desc 'Build mruby with our build config'

--- a/build_config.rb
+++ b/build_config.rb
@@ -18,7 +18,7 @@ MRuby::Build.new do |conf|
   conf.gem mgem: 'mruby-yaml'
   conf.gem mgem: 'mruby-dir'
   conf.gem mgem: 'mruby-env'
-  conf.gem '../ext'
+  conf.gem '../../ext'
 
   # C compiler settings
   # conf.cc do |cc|

--- a/runner.c
+++ b/runner.c
@@ -3,7 +3,7 @@
 #include <mruby/irep.h>
 #include <mruby/array.h>
 #include <mruby/value.h>
-#include <mainrb.c>
+#include <pkg/mainrb.c>
 
 int
 main(int argc, char ** argv)


### PR DESCRIPTION
This is a great tool and I love using it! However it is also a great example of how to package a ruby app with mruby. So I spent time reverse engineering how you did it. In an effort to minimize the pollution of build artifacts in the root of the directory but also more selfishly to make this more reusable myself in other projects I changed the build process to contain the build artifacts in `pkg`. 

I hope this is a helpful change!